### PR TITLE
Sanitize & refactor gameState.lastUpdate regexes

### DIFF
--- a/src/generatePlayerBattingStats.ts
+++ b/src/generatePlayerBattingStats.ts
@@ -398,7 +398,8 @@ pipeline.on('data', (gameDataUpdate) => {
       .replace(/\bScores Baserunner\b/, '');
 
     const lastUpdateMatchesAny = (...pieces: string[]) => {
-      const regex = new RegExp(`\b(?:${pieces.join('|')})\b`, 'i');
+      const regex = new RegExp(`\\b(?:${pieces.join('|')})\\b`, 'i');
+
       return regex.test(sanitizedLastUpdate);
     };
 

--- a/src/generatePlayerBattingStats.ts
+++ b/src/generatePlayerBattingStats.ts
@@ -393,12 +393,30 @@ pipeline.on('data', (gameDataUpdate) => {
       currBatterSummary.appearances += 1;
     }
 
+    const sanitizedLastUpdate = gameState.lastUpdate
+      // A name so powerful that we must hide it from the regex to come
+      .replace(/\bScores Baserunner\b/, '');
+
+    const lastUpdateMatchesAny = (...pieces: string[]) ==> {
+      const regex = new RegExp(`\b(?:${pieces.join('|')})\b`, 'i');
+      return regex.test(sanitizedLastUpdate);
+    };
+
     // Increment plate appearances, defined as PA = H, BB, K, HBP, SH, SF, DI, E, DFO
     if (
       prevBatterSummary &&
-      gameState.lastUpdate.match(
-        /(hits a|hit into|fielder's choice|strikes out|struck out|ground out|flyout|sacrifice|draws a walk|with a pitch)/i
-      ) !== null
+      lastUpdateMatchesAny(
+        'hits a',
+        'hit into',
+        'fielder\'s choice',
+        'strikes out',
+        'struck out',
+        'ground out',
+        'flyout',
+        'sacrifice',
+        'draws a walk',
+        'with a pitch',
+      )
     ) {
       prevBatterSummary.plateAppearances += 1;
     }
@@ -406,9 +424,15 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment at bats
     if (
       prevBatterSummary &&
-      gameState.lastUpdate.match(
-        /(hits a|hit into|fielder's choice|strikes out|struck out|ground out|flyout)/i
-      ) !== null
+      lastUpdateMatchesAny(
+        'hits a',
+        'hit into',
+        'fielder\'s choice',
+        'strikes out',
+        'struck out',
+        'ground out',
+        'flyout',
+      )
     ) {
       prevBatterSummary.atBats += 1;
 
@@ -423,7 +447,7 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment runs batted in
     if (
       prevBatterSummary &&
-      gameState.lastUpdate.match(/(home run|score|grand slam)/i) !== null
+      lastUpdateMatchesAny('home run', 'score', 'grand slam')
     ) {
       prevBatterSummary.runsBattedIn +=
         gameState.halfInningScore - prevGameState.halfInningScore;
@@ -432,7 +456,7 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment runs scored for home runs
     if (
       prevBatterSummary &&
-      gameState.lastUpdate.match(/(home run|grand slam)/i) !== null
+      lastUpdateMatchesAny('home run', 'grand slam')
     ) {
       // Increment batter's runs scored
       prevBatterSummary.runsScored += 1;
@@ -459,8 +483,8 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment runs scored for following scenarios
     // [x] - Lang Richardson hits a Single! 1 scores.
     // [x] - Juice Collins hits a Single! 2s score.
-    const numberOfRunsScoredMatch = gameState.lastUpdate.match(
-      /(\d+)s? scores?\b/i
+    const numberOfRunsScoredMatch = sanitizedLastUpdate.match(
+      /\b(\d+)s? scores?\b/i
     );
     if (prevGameState && numberOfRunsScoredMatch !== null) {
       const runsScored = Number(numberOfRunsScoredMatch[1]);
@@ -492,7 +516,7 @@ pipeline.on('data', (gameDataUpdate) => {
       // [x] - Paula Mason draws a walk. Baby Urlacher scores!
     } else if (
       prevGameState &&
-      gameState.lastUpdate.match(/ scores?\b/i) !== null
+      lastUpdateMatchesAny('scores?')
     ) {
       const scoringRunnerId = prevGameState.baseRunners[0];
 
@@ -515,7 +539,7 @@ pipeline.on('data', (gameDataUpdate) => {
     // [x] - Hendricks Rangel hits a grand slam!
     if (
       prevGameState &&
-      gameState.lastUpdate.match(/home run|grand slam/i) !== null
+      lastUpdateMatchesAny('home run', 'grand slam')
     ) {
       for (const scoringRunnerId of prevGameState.baseRunners) {
         // Increment runs scored for runner on third
@@ -535,7 +559,7 @@ pipeline.on('data', (gameDataUpdate) => {
     }
 
     // Increment hits
-    if (prevBatterSummary && gameState.lastUpdate.match(/(hits a)/i) !== null) {
+    if (prevBatterSummary && lastUpdateMatchesAny('hits a')) {
       prevBatterSummary.hits += 1;
 
       if (
@@ -549,7 +573,7 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment doubles hit
     if (
       prevBatterSummary &&
-      gameState.lastUpdate.match(/(hits a double)/i) !== null
+      lastUpdateMatchesAny('hits a double')
     ) {
       prevBatterSummary.doublesHit += 1;
     }
@@ -557,7 +581,7 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment triples hit
     if (
       prevBatterSummary &&
-      gameState.lastUpdate.match(/(hits a triple)/i) !== null
+      lastUpdateMatchesAny('hits a triple')
     ) {
       prevBatterSummary.triplesHit += 1;
     }
@@ -565,7 +589,7 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment quadruples hit
     if (
       prevBatterSummary &&
-      gameState.lastUpdate.match(/(hits a Quadruple)/i) !== null
+      lastUpdateMatchesAny('hits a Quadruple')
     ) {
       prevBatterSummary.quadruplesHit += 1;
     }
@@ -573,7 +597,7 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment home runs hit
     if (
       prevBatterSummary &&
-      gameState.lastUpdate.match(/(home run|grand slam)/i) !== null
+      lastUpdateMatchesAny('home run', 'grand slam')
     ) {
       prevBatterSummary.homeRunsHit += 1;
     }
@@ -581,7 +605,7 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment bases on balls
     if (
       prevBatterSummary &&
-      gameState.lastUpdate.match(/(walk|with a pitch)/i) !== null
+      lastUpdateMatchesAny('walk', 'with a pitch')
     ) {
       prevBatterSummary.basesOnBalls += 1;
     }
@@ -589,7 +613,7 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment hit by pitches
     if (
       prevBatterSummary &&
-      gameState.lastUpdate.match(/with a pitch/i) !== null
+      lastUpdateMatchesAny('with a pitch')
     ) {
       prevBatterSummary.hitByPitches += 1;
     }
@@ -597,7 +621,7 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment strikeouts
     if (
       prevBatterSummary &&
-      gameState.lastUpdate.match(/(strikes out|struck out)/i) !== null
+      lastUpdateMatchesAny('strikes out', 'struck out')
     ) {
       prevBatterSummary.strikeouts += 1;
     }
@@ -605,7 +629,7 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment ground into double plays
     if (
       prevBatterSummary &&
-      gameState.lastUpdate.match(/hit into a double play/i) !== null
+      lastUpdateMatchesAny('hit into a double play')
     ) {
       prevBatterSummary.groundIntoDoublePlays += 1;
     }
@@ -613,7 +637,7 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment sacrifice bunts/hits
     if (
       prevBatterSummary &&
-      gameState.lastUpdate.match(/scores on the sacrifice/i) !== null
+      lastUpdateMatchesAny('scores on the sacrifice')
     ) {
       prevBatterSummary.sacrificeBunts += 1;
     }
@@ -621,14 +645,14 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment sacrifice flies
     if (
       prevBatterSummary &&
-      gameState.lastUpdate.match(/sacrifice fly/i) !== null
+      lastUpdateMatchesAny('sacrifice fly')
     ) {
       prevBatterSummary.sacrificeFlies += 1;
     }
 
     // Increment steals
     // @TODO: Check the semantics of what qualifies as a steal
-    const stolenBaseMatch = gameState.lastUpdate.match(/steals ([\w].*?)!/i);
+    const stolenBaseMatch = sanitizedLastUpdate.match(/\bsteals ([\w].*?)!/i);
     if (prevGameState && stolenBaseMatch !== null) {
       const prevBasesOccupied = prevGameState.basesOccupied.slice();
       const basesOccupied = gameState.basesOccupied.slice();
@@ -669,8 +693,8 @@ pipeline.on('data', (gameDataUpdate) => {
     // Increment caught stealing
     // @TODO: Check the semantics of what qualifies as caught stealing
     // @TODO: Check what happens when caught stealing out ends the inning
-    const caughtStealingMatch = gameState.lastUpdate.match(
-      /([\w].*?) gets caught stealing/i
+    const caughtStealingMatch = sanitizedLastUpdate.match(
+      /\b([\w].*?) gets caught stealing\b/i
     );
     if (prevGameState && caughtStealingMatch !== null) {
       const caughtStealingName = caughtStealingMatch[1];
@@ -695,8 +719,8 @@ pipeline.on('data', (gameDataUpdate) => {
 
     // Update player attributes following incineration
     // @TODO: Handle at-bat substitutions..?
-    const incineratedPlayerMatch = gameState.lastUpdate.match(
-      /Rogue Umpire incinerated [\w\s]+ hitter ([\w\s]+)!/i
+    const incineratedPlayerMatch = sanitizedLastUpdate.match(
+      /\bRogue Umpire incinerated [\w\s]+ hitter ([\w\s]+)!/i
     );
     if (prevGameState && incineratedPlayerMatch !== null) {
       const incineratedPlayerName: string = incineratedPlayerMatch[1];

--- a/src/generatePlayerBattingStats.ts
+++ b/src/generatePlayerBattingStats.ts
@@ -397,7 +397,7 @@ pipeline.on('data', (gameDataUpdate) => {
       // A name so powerful that we must hide it from the regex to come
       .replace(/\bScores Baserunner\b/, '');
 
-    const lastUpdateMatchesAny = (...pieces: string[]) ==> {
+    const lastUpdateMatchesAny = (...pieces: string[]) => {
       const regex = new RegExp(`\b(?:${pieces.join('|')})\b`, 'i');
       return regex.test(sanitizedLastUpdate);
     };
@@ -408,14 +408,14 @@ pipeline.on('data', (gameDataUpdate) => {
       lastUpdateMatchesAny(
         'hits a',
         'hit into',
-        'fielder\'s choice',
+        "fielder's choice",
         'strikes out',
         'struck out',
         'ground out',
         'flyout',
         'sacrifice',
         'draws a walk',
-        'with a pitch',
+        'with a pitch'
       )
     ) {
       prevBatterSummary.plateAppearances += 1;
@@ -427,11 +427,11 @@ pipeline.on('data', (gameDataUpdate) => {
       lastUpdateMatchesAny(
         'hits a',
         'hit into',
-        'fielder\'s choice',
+        "fielder's choice",
         'strikes out',
         'struck out',
         'ground out',
-        'flyout',
+        'flyout'
       )
     ) {
       prevBatterSummary.atBats += 1;
@@ -454,10 +454,7 @@ pipeline.on('data', (gameDataUpdate) => {
     }
 
     // Increment runs scored for home runs
-    if (
-      prevBatterSummary &&
-      lastUpdateMatchesAny('home run', 'grand slam')
-    ) {
+    if (prevBatterSummary && lastUpdateMatchesAny('home run', 'grand slam')) {
       // Increment batter's runs scored
       prevBatterSummary.runsScored += 1;
 
@@ -514,10 +511,7 @@ pipeline.on('data', (gameDataUpdate) => {
       // [x] - Marco Stink  scores on the sacrifice.
       // [x] - Morrow Doyle hit a sacrifice fly. Esme Ramsey tags up and scores!
       // [x] - Paula Mason draws a walk. Baby Urlacher scores!
-    } else if (
-      prevGameState &&
-      lastUpdateMatchesAny('scores?')
-    ) {
+    } else if (prevGameState && lastUpdateMatchesAny('scores?')) {
       const scoringRunnerId = prevGameState.baseRunners[0];
 
       // Increment runs scored for runner on third
@@ -537,10 +531,7 @@ pipeline.on('data', (gameDataUpdate) => {
 
     // [x] - Hurley Pacheco hits a 3-run home run!
     // [x] - Hendricks Rangel hits a grand slam!
-    if (
-      prevGameState &&
-      lastUpdateMatchesAny('home run', 'grand slam')
-    ) {
+    if (prevGameState && lastUpdateMatchesAny('home run', 'grand slam')) {
       for (const scoringRunnerId of prevGameState.baseRunners) {
         // Increment runs scored for runner on third
         // - @TODO: Add initial batter object if it doesn't exist
@@ -571,50 +562,32 @@ pipeline.on('data', (gameDataUpdate) => {
     }
 
     // Increment doubles hit
-    if (
-      prevBatterSummary &&
-      lastUpdateMatchesAny('hits a double')
-    ) {
+    if (prevBatterSummary && lastUpdateMatchesAny('hits a double')) {
       prevBatterSummary.doublesHit += 1;
     }
 
     // Increment triples hit
-    if (
-      prevBatterSummary &&
-      lastUpdateMatchesAny('hits a triple')
-    ) {
+    if (prevBatterSummary && lastUpdateMatchesAny('hits a triple')) {
       prevBatterSummary.triplesHit += 1;
     }
 
     // Increment quadruples hit
-    if (
-      prevBatterSummary &&
-      lastUpdateMatchesAny('hits a Quadruple')
-    ) {
+    if (prevBatterSummary && lastUpdateMatchesAny('hits a Quadruple')) {
       prevBatterSummary.quadruplesHit += 1;
     }
 
     // Increment home runs hit
-    if (
-      prevBatterSummary &&
-      lastUpdateMatchesAny('home run', 'grand slam')
-    ) {
+    if (prevBatterSummary && lastUpdateMatchesAny('home run', 'grand slam')) {
       prevBatterSummary.homeRunsHit += 1;
     }
 
     // Increment bases on balls
-    if (
-      prevBatterSummary &&
-      lastUpdateMatchesAny('walk', 'with a pitch')
-    ) {
+    if (prevBatterSummary && lastUpdateMatchesAny('walk', 'with a pitch')) {
       prevBatterSummary.basesOnBalls += 1;
     }
 
     // Increment hit by pitches
-    if (
-      prevBatterSummary &&
-      lastUpdateMatchesAny('with a pitch')
-    ) {
+    if (prevBatterSummary && lastUpdateMatchesAny('with a pitch')) {
       prevBatterSummary.hitByPitches += 1;
     }
 
@@ -627,26 +600,17 @@ pipeline.on('data', (gameDataUpdate) => {
     }
 
     // Increment ground into double plays
-    if (
-      prevBatterSummary &&
-      lastUpdateMatchesAny('hit into a double play')
-    ) {
+    if (prevBatterSummary && lastUpdateMatchesAny('hit into a double play')) {
       prevBatterSummary.groundIntoDoublePlays += 1;
     }
 
     // Increment sacrifice bunts/hits
-    if (
-      prevBatterSummary &&
-      lastUpdateMatchesAny('scores on the sacrifice')
-    ) {
+    if (prevBatterSummary && lastUpdateMatchesAny('scores on the sacrifice')) {
       prevBatterSummary.sacrificeBunts += 1;
     }
 
     // Increment sacrifice flies
-    if (
-      prevBatterSummary &&
-      lastUpdateMatchesAny('sacrifice fly')
-    ) {
+    if (prevBatterSummary && lastUpdateMatchesAny('sacrifice fly')) {
       prevBatterSummary.sacrificeFlies += 1;
     }
 

--- a/src/generatePlayerPitchingStats.ts
+++ b/src/generatePlayerPitchingStats.ts
@@ -496,7 +496,7 @@ pipeline.on('data', (gameDataUpdate) => {
       // A name so powerful that we must hide it from the regex to come
       .replace(/\bScores Baserunner\b/, '');
 
-    const lastUpdateMatchesAny = (...pieces: string[]) ==> {
+    const lastUpdateMatchesAny = (...pieces: string[]) => {
       const regex = new RegExp(`\b(?:${pieces.join('|')})\b`, 'i');
       return regex.test(sanitizedLastUpdate);
     };
@@ -517,8 +517,8 @@ pipeline.on('data', (gameDataUpdate) => {
         'strikes out',
         'struck out',
         'caught stealing',
-        'fielder\'s choice',
-        'sacrifice',
+        "fielder's choice",
+        'sacrifice'
       )
     ) {
       prevPitcherSummary.outsRecorded += 1;
@@ -539,8 +539,8 @@ pipeline.on('data', (gameDataUpdate) => {
         'reaches',
         'steals',
         'caught stealing',
-        'fielder\'s choice',
-        'sacrifice',
+        "fielder's choice",
+        'sacrifice'
       )
     ) {
       prevPitcherSummary.pitchCount += 1;
@@ -571,7 +571,7 @@ pipeline.on('data', (gameDataUpdate) => {
     // Update player attributes following incineration
     // @TODO: Handle pitcher substitutions..?
     const incineratedPlayerMatch = sanitizedLastUpdate.match(
-      /\bRogue Umpire incinerated [\w\s]+ pitcher ([\w\s]+)!\b/i,
+      /\bRogue Umpire incinerated [\w\s]+ pitcher ([\w\s]+)!\b/i
     );
     if (prevGameState && incineratedPlayerMatch !== null) {
       const incineratedPlayerName = incineratedPlayerMatch[1];
@@ -606,19 +606,13 @@ pipeline.on('data', (gameDataUpdate) => {
     }
 
     // Increment hit by pitches
-    if (
-      prevPitcherSummary &&
-      lastUpdateMatchesAny('with a pitch')
-    ) {
+    if (prevPitcherSummary && lastUpdateMatchesAny('with a pitch')) {
       prevPitcherSummary.hitByPitches += 1;
     }
 
     // Increment strikeouts
     // @TODO: Check to see if currPitcher changes if strikeout leads to inning change
-    if (
-      prevGameState &&
-      lastUpdateMatchesAny('strikes out|struck out')
-    ) {
+    if (prevGameState && lastUpdateMatchesAny('strikes out|struck out')) {
       prevPitcherSummary.strikeouts += 1;
     }
 
@@ -648,10 +642,7 @@ pipeline.on('data', (gameDataUpdate) => {
     }
 
     // Increment home runs allowed
-    if (
-      prevGameState &&
-      lastUpdateMatchesAny('home run', 'grand slam')
-    ) {
+    if (prevGameState && lastUpdateMatchesAny('home run', 'grand slam')) {
       prevPitcherSummary.homeRuns += 1;
     }
 

--- a/src/generatePlayerPitchingStats.ts
+++ b/src/generatePlayerPitchingStats.ts
@@ -497,7 +497,7 @@ pipeline.on('data', (gameDataUpdate) => {
       .replace(/\bScores Baserunner\b/, '');
 
     const lastUpdateMatchesAny = (...pieces: string[]) => {
-      const regex = new RegExp(`\b(?:${pieces.join('|')})\b`, 'i');
+      const regex = new RegExp(`\\b(?:${pieces.join('|')})\\b`, 'i');
       return regex.test(sanitizedLastUpdate);
     };
 


### PR DESCRIPTION
We want to ignore a _certain player_'s name in the update strings, and match against a number of possibilities otherwise. This refactors that matching logic into a new method, `lastUpdateMatchesAny`, which combines its arguments into a valid regex and checks for that.